### PR TITLE
Remove @Override

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNVolumePackage.java
+++ b/android/src/main/java/com/reactlibrary/RNVolumePackage.java
@@ -16,7 +16,8 @@ public class RNVolumePackage implements ReactPackage {
       return Arrays.<NativeModule>asList(new RNVolumeModule(reactContext));
     }
 
-    @Override
+    //As of RN 47.2, this method is no longer in the interface.  Keeping here to be backwards compatible.
+    //https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8
     public List<Class<? extends JavaScriptModule>> createJSModules() {
       return Collections.emptyList();
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 
 {
   "name": "react-native-volume",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "author": "",
   "license": "",
   "peerDependencies": {
-    "react-native": "^0.41.2",
-    "react-native-windows": "0.41.0-rc.1"
+    "react-native": "^0.47.1",
+    "react-native-windows": "0.47.0-rc.5"
 
   }
 }


### PR DESCRIPTION
As of RN47.2 ReactPackage no longer provides createJSModules.

Keep the function w/out the Override to be backwards compatible.